### PR TITLE
fix: deploy 스크립트에서 s3 sync --delete 제거

### DIFF
--- a/admin_sunny/package.json
+++ b/admin_sunny/package.json
@@ -29,7 +29,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "deploy": "react-scripts build && aws s3 sync build/ s3://admin.awskrug-sls.com --delete && aws cloudfront create-invalidation --distribution-id E1G8PD5CZYL2NR --paths \"/*\""
+    "deploy": "react-scripts build && aws s3 sync build/ s3://admin.awskrug-sls.com && aws cloudfront create-invalidation --distribution-id E1G8PD5CZYL2NR --paths \"/*\""
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
배포 IAM 사용자(sam-deploy)에 s3:DeleteObject 권한이 없어 --delete가 AccessDenied로 실패 → aws s3 sync가 비정상 종료 → 뒤따르는 CloudFront 무효화(&&)가 실행되지 않던 문제를 해결.

CRA 산출물은 파일명이 해시라 옛 파일이 남아도 무해하고, index.html은
sync가 갱신 + 무효화로 캐시 정리됨.